### PR TITLE
spring-boot-http-gradle to 0.0.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,4 +12,4 @@ dependencies:
   version: 0.0.1
 - name: spring-boot-http-gradle
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.2
+  version: 0.0.4


### PR DESCRIPTION
Promote spring-boot-http-gradle to version 0.0.4